### PR TITLE
Machine Timer Registers (mtime and mtimecmp) and control registers

### DIFF
--- a/ip/mtimer.md
+++ b/ip/mtimer.md
@@ -1,0 +1,62 @@
+
+
+# MTIMER
+
+## Initialization
+
+1. Write the count register `MTIME` and comparison register `MTIMECMP`;
+2. Enable the timer by writing the `EN` bit to the `CR` register.
+
+## Register Access
+
+MTIMER IP has a 64-bit count register `MTIME` and a 64-bit comparison register `MTIMECMP`. Registers are accessed via 32-bit access operations. Attempts to access an misaligned address will be ignored.
+
+## Interrupt Handling
+
+The machine timer interrupt becomes pending whenever `MTIME` contains a value greater than or equal to `MTIMECMP`. The interrupt can be cleared by updating `MTIME` or `MTIMECMP`.
+
+## Registers
+
+| Name                       | Offset | Bits  | Description            |
+|:---------------------------|:-------|------ |:-----------------------|
+| [`CR`](#CR)                | 0x0    |    32 | Control register       |
+| [`MTIMEL`](#MTIMEL)        | 0x4    |    32 | Timer value Low        |
+| [`MTIMEH`](#MTIMEH)        | 0x8    |    32 | Timer value High       |
+| [`MTIMECMPL`](#MTIMECMPL)  | 0xC    |    32 | Timer compare Low      |
+| [`MTIMECMPH`](#MTIMECMPH)  | 0x10   |    32 | Timer compare High     |
+
+
+### MTIMER control register (MTIMER_CR)
+
+- Address offset: `0x0`
+- Reset value: `0x0`
+- Bits 31:1 Reserved, must be kept at reset value
+- Bit 0 `EN` Enable count
+
+
+### MTIMER counter register (MTIMER_MTIMEL)
+
+- Address offset: `0x4`
+- Reset value: `0x0`
+- Bits 31:0 `MTIMEL`: Timer value Low
+
+
+### MTIMER counter register (MTIMER_MTIMEH)
+
+- Address offset: `0x8`
+- Reset value: `0x0`
+- Bits 31:0 `MTIMEH`: Timer value High
+
+
+### MTIMER compare register (MTIMER_MTIMECMPL)
+
+- Address offset: `0xC`
+- Reset value: `0x0`
+- Bits 31:0 `MTIMECMPL`: Timer compare Low
+
+
+### MTIMER compare register (MTIMER_MTIMECMPH)
+
+- Address offset: `0xC`
+- Reset value: `0x0`
+- Bits 31:0 `MTIMECMPH`: Timer compare High

--- a/ip/mtimer.md
+++ b/ip/mtimer.md
@@ -15,15 +15,18 @@ MTIMER IP has a 64-bit count register `MTIME` and a 64-bit comparison register `
 
 The machine timer interrupt becomes pending whenever `MTIME` contains a value greater than or equal to `MTIMECMP`. The interrupt can be cleared by updating `MTIME` or `MTIMECMP`.
 
+`output irq` is set high whenever `MTIME >= MTIMECMP`. The `irq_response` input is not used, left for future implementations.
+
+
 ## Registers
 
 | Name                       | Offset | Bits  | Description            |
 |:---------------------------|:-------|------ |:-----------------------|
-| [`CR`](#CR)                | 0x0    |    32 | Control register       |
-| [`MTIMEL`](#MTIMEL)        | 0x4    |    32 | Timer value Low        |
-| [`MTIMEH`](#MTIMEH)        | 0x8    |    32 | Timer value High       |
-| [`MTIMECMPL`](#MTIMECMPL)  | 0xC    |    32 | Timer compare Low      |
-| [`MTIMECMPH`](#MTIMECMPH)  | 0x10   |    32 | Timer compare High     |
+| [`CR`](#cr)                | 0x0    |    32 | Control register       |
+| [`MTIMEL`](#mtimel)        | 0x4    |    32 | Timer value Low        |
+| [`MTIMEH`](#mtimeh)        | 0x8    |    32 | Timer value High       |
+| [`MTIMECMPL`](#mtimecmpl)  | 0xC    |    32 | Timer compare Low      |
+| [`MTIMECMPH`](#mtimecmph)  | 0x10   |    32 | Timer compare High     |
 
 
 ### MTIMER control register (MTIMER_CR)
@@ -57,6 +60,6 @@ The machine timer interrupt becomes pending whenever `MTIME` contains a value gr
 
 ### MTIMER compare register (MTIMER_MTIMECMPH)
 
-- Address offset: `0xC`
+- Address offset: `0x10`
 - Reset value: `0x0`
 - Bits 31:0 `MTIMECMPH`: Timer compare High

--- a/ip/mtimer.v
+++ b/ip/mtimer.v
@@ -1,0 +1,207 @@
+
+
+
+module mtimer #(
+
+) (
+
+  // Global signals
+
+  input   wire          clock         ,
+  input   wire          reset         ,
+
+  // IO interface
+
+  input   wire  [31:0]  rw_address    ,
+  output  reg   [31:0]  read_data     ,
+  input   wire          read_request  ,
+  output  reg           read_response ,
+  input   wire  [31:0]  write_data    ,
+  input   wire  [3:0 ]  write_strobe  ,
+  input   wire          write_request ,
+  output  reg           write_response,
+
+  // TODO: use it later
+  // output  reg        access_fault  ,
+
+  // Side timer irq
+  // Interrupt signaling
+
+  output  reg           irq           ,
+  input   wire          irq_response
+
+);
+
+  // verilator lint_off UNUSED
+
+  localparam REG_ADDR_WIDTH   = 'd3;
+
+  // Map registers
+  localparam REG_CR           = 'd0;
+  localparam REG_MTIMEL       = 'd1;
+  localparam REG_MTIMEH       = 'd2;
+  localparam REG_MTIMECMPL    = 'd3;
+  localparam REG_MTIMECMPH    = 'd4;
+
+  // Map bits
+  // CR
+  localparam BIT_CR_EN        = 'd0;
+  localparam BIT_CR_WIDTH     = 'd1;
+  localparam CR_PADDING       = {'d32-BIT_CR_WIDTH{1'd0}};
+
+  // verilator lint_on UNUSED
+
+
+  // Control register
+  reg cr_update;
+  reg cr_en;
+
+  // mtime
+  reg mtime_l_update;
+  reg mtime_h_update;
+  reg [63:0] mtime;
+
+  // mtimecmp
+  reg mtimecmp_l_update;
+  reg mtimecmp_h_update;
+  reg [63:0] mtimecmp;
+
+
+  // Bus
+  wire address_aligned;
+  assign address_aligned = (~|rw_address[1:0]);
+
+  wire write_word;
+  assign write_word = (&write_strobe);
+
+  wire [REG_ADDR_WIDTH-1:0] address;
+  assign address = rw_address[2 +:REG_ADDR_WIDTH];
+
+  wire [32-REG_ADDR_WIDTH-1:0] address_unused;
+  assign address_unused = {rw_address[31:REG_ADDR_WIDTH+2], rw_address[1:0]};
+
+
+  // Exclude unused
+  wire irq_response_unused;
+  assign irq_response_unused = irq_response;
+
+
+  // Control register
+  always @(posedge clock) begin
+    if (reset) begin
+      cr_en <= 'h0;
+    end else begin
+      if (cr_update) begin
+        cr_en <= write_data[BIT_CR_EN];
+      end
+    end
+  end
+
+
+  // mtime
+  always @(posedge clock) begin
+    if (reset) begin
+      mtime <= 'h0;
+    end else begin
+      if (cr_en) begin
+        mtime <= mtime + 'h1;
+      end
+
+      if (mtime_l_update) begin
+        mtime[31:0] <= write_data;
+      end
+
+      if (mtime_h_update) begin
+        mtime[63:32] <= write_data;
+      end
+    end
+  end
+
+
+  // mtimecmp
+  always @(posedge clock) begin
+    if (reset) begin
+      mtimecmp <= 'h0;
+    end else begin
+      if (mtimecmp_l_update) begin
+        mtimecmp[31:0] <= write_data;
+      end
+
+      if (mtimecmp_h_update) begin
+        mtimecmp[63:32] <= write_data;
+      end
+    end
+  end
+
+
+  // IRQ
+  always @(posedge clock) begin
+    if (reset) begin
+      irq <= 'h0;
+    end else begin
+      // Don't update while there is an update
+      if (~(mtime_l_update | mtime_h_update | mtimecmp_l_update | mtimecmp_h_update)) begin
+        // A machine timer interrupt becomes pending whenever mtime contains a
+        // value greater than or equal to mtimecmp
+        irq <= (mtime >= mtimecmp);
+      end
+    end
+  end
+
+
+  // Bus: Response to request
+  always @(posedge clock) begin
+    if (reset) begin
+      read_response <= 'h0;
+      write_response <= 'h0;
+      // access_fault <= 'h0;
+    end else begin
+      read_response <= read_request;
+      write_response <= write_request;
+      // access_fault <= (read_request & !address_aligned) |
+      //                 (write_request & !address_aligned) |
+      //                 (write_request & !write_word);
+    end
+  end
+
+
+  // Bus: Read registers
+  always @(posedge clock) begin
+    if (reset) begin
+      read_data <= 'h0;
+    end else begin
+      if (read_request && address_aligned) begin
+        case (address)
+          REG_CR        : read_data <= {CR_PADDING, cr_en};
+          REG_MTIMEL    : read_data <= mtime[31:0];
+          REG_MTIMEH    : read_data <= mtime[63:32];
+          REG_MTIMECMPL : read_data <= mtimecmp[31:0];
+          REG_MTIMECMPH : read_data <= mtimecmp[63:32];
+          default: begin end
+        endcase
+      end
+    end
+  end
+
+
+  // Bus: Update registers
+  always @(*) begin
+    cr_update         = 'h0;
+    mtime_l_update    = 'h0;
+    mtime_h_update    = 'h0;
+    mtimecmp_l_update = 'h0;
+    mtimecmp_h_update = 'h0;
+
+    if (write_request && address_aligned && write_word) begin
+        case (address)
+            REG_CR        : cr_update         = 'h1;
+            REG_MTIMEL    : mtime_l_update    = 'h1;
+            REG_MTIMEH    : mtime_h_update    = 'h1;
+            REG_MTIMECMPL : mtimecmp_l_update = 'h1;
+            REG_MTIMECMPH : mtimecmp_h_update = 'h1;
+            default: begin end
+        endcase
+    end
+  end
+
+endmodule

--- a/ip/mtimer.v
+++ b/ip/mtimer.v
@@ -1,5 +1,9 @@
-
-
+// ----------------------------------------------------------------------------
+// Copyright (c) 2020-2024 RISC-V Steel contributors
+//
+// This work is licensed under the MIT License, see LICENSE file for details.
+// SPDX-License-Identifier: MIT
+// ----------------------------------------------------------------------------
 
 module mtimer #(
 

--- a/tests/mtimer/.gitignore
+++ b/tests/mtimer/.gitignore
@@ -1,0 +1,14 @@
+# Python
+__pycache__
+
+# Waveforms
+*.vcd
+*.fst
+
+# Results
+results.xml
+sim_build
+
+# VCS files
+*.tab
+ucli.key

--- a/tests/mtimer/Makefile
+++ b/tests/mtimer/Makefile
@@ -1,0 +1,21 @@
+# This file is public domain, it can be freely copied without restrictions.
+# SPDX-License-Identifier: CC0-1.0
+
+# Makefile
+
+SIM ?= verilator
+TOPLEVEL_LANG ?= verilog
+
+# Or --trace-fst
+EXTRA_ARGS ?= --trace
+
+VERILOG_SOURCES += $(PWD)/../../ip/mtimer.v
+
+# TOPLEVEL is the name of the toplevel module in your Verilog or VHDL file
+TOPLEVEL = mtimer
+
+# MODULE is the basename of the Python test file
+MODULE = test_mtimer
+
+# include cocotb's make rules to take care of the simulator setup
+include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/tests/mtimer/README.md
+++ b/tests/mtimer/README.md
@@ -1,0 +1,14 @@
+# MTIMER IP Tests
+
+## How do I run the tests?
+
+To run the unit tests do:
+
+```bash
+make
+```
+
+#### Dependencies
+> `Verilator 5.006 and later`: [Installation](https://veripool.org/guide/latest/install.html)
+
+> `cocotb 1.8.0 and later`: [Installation](https://docs.cocotb.org/en/stable/install.html)

--- a/tests/mtimer/test_mtimer.py
+++ b/tests/mtimer/test_mtimer.py
@@ -1,3 +1,10 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) 2020-2024 RISC-V Steel contributors
+#
+# This work is licensed under the MIT License, see LICENSE file for details.
+# SPDX-License-Identifier: MIT
+# -----------------------------------------------------------------------------
+
 import cocotb
 from cocotb.clock import Clock
 from cocotb.triggers import Timer

--- a/tests/mtimer/test_mtimer.py
+++ b/tests/mtimer/test_mtimer.py
@@ -1,0 +1,101 @@
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import Timer
+from cocotb.triggers import ClockCycles
+from cocotb.triggers import RisingEdge
+
+
+CLK_PERIOD_NS   = 100
+
+REG_CR          = 0*4
+REG_MTIMEL      = 1*4
+REG_MTIMEH      = 2*4
+REG_MTIMECMPL   = 3*4
+REG_MTIMECMPH   = 4*4
+
+
+def setup_dut(dut):
+    cocotb.start_soon(Clock(dut.clock, CLK_PERIOD_NS, units='ns').start())
+
+
+async def reset_dut(dut):
+    dut.reset.value = 1
+    await ClockCycles(dut.clock, 10)
+    dut.reset.value = 0
+    await ClockCycles(dut.clock, 10)
+
+
+async def write_request(dut, add, value, strobe=0xf):
+    await RisingEdge(dut.clock)
+    dut.rw_address.value = add
+    dut.write_data.value = value
+    dut.write_strobe.value = strobe
+    dut.write_request.value = 1
+    await RisingEdge(dut.write_response)
+    dut.write_request.value = 0
+    await RisingEdge(dut.clock)
+
+
+async def read_request(dut, add):
+    await RisingEdge(dut.clock)
+    dut.rw_address.value = add
+    dut.read_request.value = 1
+    await RisingEdge(dut.read_response)
+    data = dut.read_data.value
+    dut.read_request.value = 0
+    await RisingEdge(dut.clock)
+    return data
+
+
+@cocotb.test()
+async def test_irq(dut):
+    setup_dut(dut)
+    await reset_dut(dut)
+    await Timer(1, units='us')
+
+    # Reset, mtime == mtimecmp and irq out == 1
+    assert dut.mtime.value == dut.mtimecmp.value
+    assert dut.irq.value == 1
+
+    await write_request(dut, add=REG_MTIMEL, value=10)
+    await write_request(dut, add=REG_MTIMEH, value=0)
+
+    await write_request(dut, add=REG_MTIMECMPL, value=20)
+    await write_request(dut, add=REG_MTIMECMPH, value=0)
+
+    # Reset, mtime > mtimecmp and irq out == 0
+    assert dut.irq.value == 0
+
+    await Timer(CLK_PERIOD_NS*10*2, units='ns')
+
+    # Reset, mtime > mtimecmp and irq out == 0, mtimer disable
+    assert dut.irq.value == 0
+
+    # mtimer enable
+    await write_request(dut, add=REG_CR, value=1)
+    await Timer(CLK_PERIOD_NS*11, units='ns')
+
+    # Reset, mtime >= mtimecmp and irq out == 1, mtimer enable
+    assert dut.irq.value == 1
+
+
+@cocotb.test()
+async def test_address_misaligned(dut):
+    setup_dut(dut)
+    await reset_dut(dut)
+    await Timer(1, units='us')
+
+    await write_request(dut, add=REG_CR, value=1)
+    await Timer(CLK_PERIOD_NS*11, units='ns')
+
+    cr = await read_request(dut, add=REG_CR)
+    assert cr == 1
+
+    # misaligned
+    await write_request(dut, add=REG_CR+1, value=0)
+
+    # TODO: use it later
+    # assert dut.access_fault.value == 1
+
+    cr = await read_request(dut, add=REG_CR)
+    assert cr == 1


### PR DESCRIPTION
Added implementation of a machine timer with count, compare, and control registers. A short test based on `Verilator + cocotb`.