### PR TITLE
Fix loading mem init files in the new format in the Core IP simulator

### DIFF
--- a/hardware/core/tests/verilator/Makefile
+++ b/hardware/core/tests/verilator/Makefile
@@ -1,8 +1,9 @@
-# Project Name:  RISC-V Steel System-on-Chip - Core simulation in Verilator
-# Project Repo:  github.com/riscv-steel/riscv-steel
-# 
-# Copyright (C) Alexander Markov - github.com/AlexxMarkov
+# ----------------------------------------------------------------------------
+# Copyright (c) 2020-2024 RISC-V Steel contributors
+#
+# This work is licensed under the MIT License, see LICENSE file for details.
 # SPDX-License-Identifier: MIT
+# ----------------------------------------------------------------------------
 
 
 

--- a/hardware/core/tests/verilator/argparse.cpp
+++ b/hardware/core/tests/verilator/argparse.cpp
@@ -1,10 +1,9 @@
-/*
-Project Name:  RISC-V Steel System-on-Chip - Core simulation in Verilator
-Project Repo:  github.com/riscv-steel/riscv-steel
-
-Copyright (C) Alexander Markov - github.com/AlexxMarkov
-SPDX-License-Identifier: MIT
-*/
+// ----------------------------------------------------------------------------
+// Copyright (c) 2020-2024 RISC-V Steel contributors
+//
+// This work is licensed under the MIT License, see LICENSE file for details.
+// SPDX-License-Identifier: MIT
+// ----------------------------------------------------------------------------
 
 #include "argparse.h"
 

--- a/hardware/core/tests/verilator/argparse.cpp
+++ b/hardware/core/tests/verilator/argparse.cpp
@@ -14,7 +14,7 @@
 const char *help_str =
     "Use: app_name.run [options]\n"
     "Options:\n"
-    "--out-wave=<name>      Output file *.vcd (defaul: none - off)\n\n"
+    "--out-wave=<name>      Output file *.fst (defaul: none - off)\n\n"
     "--ram-init-h32=<name>  Input init ram file in h32 format (defaul: none - off)\n"
     "                       Example: --ram-init-h32=my_program.hex\n\n"
 

--- a/hardware/core/tests/verilator/argparse.h
+++ b/hardware/core/tests/verilator/argparse.h
@@ -1,10 +1,9 @@
-/*
-Project Name:  RISC-V Steel System-on-Chip - Core simulation in Verilator
-Project Repo:  github.com/riscv-steel/riscv-steel
-
-Copyright (C) Alexander Markov - github.com/AlexxMarkov
-SPDX-License-Identifier: MIT
-*/
+// ----------------------------------------------------------------------------
+// Copyright (c) 2020-2024 RISC-V Steel contributors
+//
+// This work is licensed under the MIT License, see LICENSE file for details.
+// SPDX-License-Identifier: MIT
+// ----------------------------------------------------------------------------
 
 
 

--- a/hardware/core/tests/verilator/main.cpp
+++ b/hardware/core/tests/verilator/main.cpp
@@ -1,10 +1,9 @@
-/*
-Project Name:  RISC-V Steel System-on-Chip - Core simulation in Verilator
-Project Repo:  github.com/riscv-steel/riscv-steel
-
-Copyright (C) Alexander Markov - github.com/AlexxMarkov
-SPDX-License-Identifier: MIT
-*/
+// ----------------------------------------------------------------------------
+// Copyright (c) 2020-2024 RISC-V Steel contributors
+//
+// This work is licensed under the MIT License, see LICENSE file for details.
+// SPDX-License-Identifier: MIT
+// ----------------------------------------------------------------------------
 
 #include <stdlib.h>
 

--- a/hardware/core/tests/verilator/main.cpp
+++ b/hardware/core/tests/verilator/main.cpp
@@ -239,7 +239,7 @@ int main(int argc, char *argv[])
       uint32_t stop_addr = get_signature(2046);
       uint32_t size = stop_addr - start_addr;
 
-      std::cout << "Signature size: " << size << std::endl;
+      std::cout << "Signature size: " << std::dec << size << std::endl;
 
       if (args.ram_dump_h32 and (size >= 4))
       {

--- a/hardware/core/tests/verilator/main.cpp
+++ b/hardware/core/tests/verilator/main.cpp
@@ -97,7 +97,7 @@ void ram_init_h32(const char *path)
   }
 
   std::string line;
-  unsigned int load_address = 0x00000000;
+  size_t load_address = 0x00000000;
   // In words
   size_t ram_size = dut->rootp->unit_tests__DOT__MEMORY_SIZE / 4;
 
@@ -120,6 +120,13 @@ void ram_init_h32(const char *path)
       else
       {
         uint32_t data = std::stoul(token_str, nullptr, 16);
+
+        if (load_address > ram_size)
+        {
+          std::cout << "Out of range load address ram: 0x" << std::hex << load_address << std::endl;
+          std::exit(EXIT_FAILURE);
+        }
+
         dut->rootp->unit_tests__DOT__rvsteel_ram_instance__DOT__ram[load_address] = data;
         token = strtok(NULL, " \n");
         load_address++;

--- a/hardware/core/tests/verilator/unit_tests.v
+++ b/hardware/core/tests/verilator/unit_tests.v
@@ -1,12 +1,9 @@
-/*
-Project Name:  RISC-V Steel System-on-Chip - Core simulation in Verilator
-Project Repo:  github.com/riscv-steel/riscv-steel
-
-Copyright (C) Alexander Markov - github.com/AlexxMarkov
-SPDX-License-Identifier: MIT
-*/
-
-
+// ----------------------------------------------------------------------------
+// Copyright (c) 2020-2024 RISC-V Steel contributors
+//
+// This work is licensed under the MIT License, see LICENSE file for details.
+// SPDX-License-Identifier: MIT
+// ----------------------------------------------------------------------------
 
 module unit_tests #
 (


### PR DESCRIPTION
Hi @AlexxMarkov, the changes I introduced in the mem init file format could not be read by the Core IP simulator. I just fixed it. I think now everything works with the new format.