### PR TITLE
Add --quiet option to Core IP simulator

### DIFF
--- a/hardware/core/tests/verilator/README.md
+++ b/hardware/core/tests/verilator/README.md
@@ -33,6 +33,10 @@ Available commands:
 
     Any entries to this address will print the messages as terminal output. The default address is 0x00000000, which means no messages.
 
+  - **--quiet**
+
+    Disable all messages.
+
 
 > Documentation for installing `Verilator` can be found here: [Installation](https://veripool.org/guide/latest/install.html)
 

--- a/hardware/core/tests/verilator/argparse.cpp
+++ b/hardware/core/tests/verilator/argparse.cpp
@@ -34,10 +34,13 @@ const char *help_str =
     "                       Example: --host-out=0x00000000\n"
     "Note:                  Must not be 0x0\n\n"
 
+    "--quiet                Use --quiet to disable messages (defaul: messages enable)\n"
+    "                       Example: --quiet\n"
+
     "\n\n"
     "Example:\n"
     "unit_tests --ram-init-h32=add-01.hex --ram-dump-h32=add-01-dump.hex"
-    "unit_tests --out-wave=wave.vcd --ram-init-h32=add-01.hex --ram-dump-h32=add-01-dump.hex"
+    "unit_tests --out-wave=wave.fst --ram-init-h32=add-01.hex --ram-dump-h32=add-01-dump.hex"
     "unit_tests --ram-init-h32=main.hex --host-out=0x4";
 
 enum opts

--- a/hardware/core/tests/verilator/argparse.cpp
+++ b/hardware/core/tests/verilator/argparse.cpp
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <iostream>
 #include <getopt.h>
+#include <string.h>
 
 const char *help_str =
     "Use: app_name.run [options]\n"
@@ -51,6 +52,7 @@ enum opts
   cmd_wr_addr,
   cmd_dump_h32,
   cmd_host_out,
+  cmd_quiet
 };
 
 static constexpr option long_opts[] =
@@ -63,6 +65,7 @@ static constexpr option long_opts[] =
         //        { "ecall",          no_argument,        NULL, opts::cmd_ecall               },
         {"wr-addr", required_argument, NULL, opts::cmd_wr_addr},
         {"host-out", required_argument, NULL, opts::cmd_host_out},
+        {"quiet", no_argument, NULL, opts::cmd_quiet},
         {NULL, no_argument, NULL, 0}};
 
 static size_t get_int_arg(const char *arg)
@@ -76,6 +79,13 @@ Args parser(int argc, char *argv[])
   Args args;
   int opt;
 
+  // Check first if --quiet was used. If so, disable output printing
+  for (int i = 0; i < argc; i++)
+    if (strcmp(argv[i], "--quiet") == 0)
+    {
+      args.sim_verbosity = QUIET;
+    }
+
   while ((opt = getopt_long(argc, argv, "", long_opts, NULL)) != -1)
   {
     switch (opt)
@@ -86,32 +96,41 @@ Args parser(int argc, char *argv[])
 
     case opts::cmd_out_wave:
       args.out_wave_path = optarg;
-      std::cout << "Wave out: " << optarg << std::endl;
+      if (args.sim_verbosity != QUIET)
+        std::cout << "Wave out: " << optarg << std::endl;
       break;
 
     case opts::cmd_ram_init_h32:
       args.ram_init_h32 = optarg;
-      std::cout << "Input init ram file: " << optarg << std::endl;
+      if (args.sim_verbosity != QUIET)
+        std::cout << "Input init ram file: " << optarg << std::endl;
       break;
 
     case opts::cmd_ram_dump_h32:
       args.ram_dump_h32 = optarg;
-      std::cout << "Output dump ram file: " << optarg << std::endl;
+      if (args.sim_verbosity != QUIET)
+        std::cout << "Output dump ram file: " << optarg << std::endl;
       break;
 
     case opts::cmd_cycles:
       args.max_cycles = get_int_arg(optarg);
-      std::cout << "Max cycles: " << args.max_cycles << std::endl;
+      if (args.sim_verbosity != QUIET)
+        std::cout << "Max cycles: " << args.max_cycles << std::endl;
       break;
 
     case opts::cmd_wr_addr:
       args.wr_addr = get_int_arg(optarg);
-      std::cout << "Write address: 0x" << std::hex << args.wr_addr << std::endl;
+      if (args.sim_verbosity != QUIET)
+        std::cout << "Write address: 0x" << std::hex << args.wr_addr << std::endl;
       break;
 
     case opts::cmd_host_out:
       args.host_out = get_int_arg(optarg);
-      std::cout << "Host out: 0x" << std::hex << args.host_out << std::endl;
+      if (args.sim_verbosity != QUIET)
+        std::cout << "Host out: 0x" << std::hex << args.host_out << std::endl;
+      break;
+
+    case opts::cmd_quiet:
       break;
 
     default:

--- a/hardware/core/tests/verilator/argparse.h
+++ b/hardware/core/tests/verilator/argparse.h
@@ -5,30 +5,29 @@
 // SPDX-License-Identifier: MIT
 // ----------------------------------------------------------------------------
 
-
-
 #ifndef ARGPARSE_H
 #define ARGPARSE_H
-
 
 #include <cstdint>
 #include <cstddef>
 
-
-
-struct Args {
-    char *out_wave_path{nullptr};
-    char *ram_init_h32{nullptr};
-    char *ram_dump_h32{nullptr};
-    uint32_t max_cycles{500000};
-    uint32_t wr_addr{0x00001000};
-    uint32_t host_out{0x00000000};
+enum verbosity
+{
+  QUIET,
+  VERBOSE
 };
 
-
+struct Args
+{
+  char *out_wave_path{nullptr};
+  char *ram_init_h32{nullptr};
+  char *ram_dump_h32{nullptr};
+  uint32_t max_cycles{500000};
+  uint32_t wr_addr{0x00001000};
+  uint32_t host_out{0x00000000};
+  verbosity sim_verbosity{VERBOSE};
+};
 
 Args parser(int argc, char *argv[]);
-
-
 
 #endif // ARGPARSE_H

--- a/hardware/core/tests/verilator/main.cpp
+++ b/hardware/core/tests/verilator/main.cpp
@@ -27,6 +27,7 @@ vluint64_t clk_cur_cycles = 0;
 vluint64_t clk_half_cycles = 2;
 Dut *dut = new Dut;
 Trace *trace = new Trace;
+Args args;
 
 static void open_trace(const char *out_wave_path)
 {
@@ -80,7 +81,8 @@ void exit_app(int sig)
 {
   (void)sig;
   close_trace();
-  std::cout << "Exit." << std::endl;
+  if (args.sim_verbosity != QUIET)
+    std::cout << "Exit." << std::endl;
   std::exit(EXIT_SUCCESS);
 }
 
@@ -134,7 +136,8 @@ void ram_init_h32(const char *path)
     }
   }
 
-  std::cout << "Ok init ram h32" << std::endl;
+  if (args.sim_verbosity != QUIET)
+    std::cout << "Ok init ram h32" << std::endl;
   file.close();
 }
 
@@ -162,7 +165,8 @@ void ram_dump_h32(const char *path, uint32_t offset, uint32_t size)
     file << buff << '\n';
   }
 
-  std::cout << "Ok dump ram h32" << std::endl;
+  if (args.sim_verbosity != QUIET)
+    std::cout << "Ok dump ram h32" << std::endl;
   file.close();
 }
 
@@ -200,7 +204,7 @@ int main(int argc, char *argv[])
   signal(SIGINT, exit_app);
   signal(SIGKILL, exit_app);
 
-  Args args = parser(argc, argv);
+  args = parser(argc, argv);
 
   if (args.out_wave_path)
   {
@@ -223,7 +227,8 @@ int main(int argc, char *argv[])
     {
       if (clk_cur_cycles >= args.max_cycles)
       {
-        std::cout << "Exit: end cycles" << std::endl;
+        if (args.sim_verbosity != QUIET)
+          std::cout << "Exit: end cycles" << std::endl;
         close_trace();
         std::exit(EXIT_SUCCESS);
       }
@@ -232,14 +237,16 @@ int main(int argc, char *argv[])
     // --wr-addr
     if (is_finished(args.wr_addr))
     {
-      std::cout << "Exit: wr-addr" << std::endl;
+      if (args.sim_verbosity != QUIET)
+        std::cout << "Exit: wr-addr" << std::endl;
 
       // The beginning and end of signature are stored at
       uint32_t start_addr = get_signature(2047);
       uint32_t stop_addr = get_signature(2046);
       uint32_t size = stop_addr - start_addr;
 
-      std::cout << "Signature size: " << std::dec << size << std::endl;
+      if (args.sim_verbosity != QUIET)
+        std::cout << "Signature size: " << std::dec << size << std::endl;
 
       if (args.ram_dump_h32 and (size >= 4))
       {


### PR DESCRIPTION
Hi @AlexxMarkov, I needed a --quiet option in the Core IP simulator so I just added it. It will be useful to use with riscv-arch-test. I wanted an option to generate the output signatures quietly. I was generating all signatures at once so the terminal output was too verbose. 