### PR TITLE
Added log-out and log-level options to Core IP simulator

### DIFF
--- a/hardware/core/tests/verilator/README.md
+++ b/hardware/core/tests/verilator/README.md
@@ -28,7 +28,6 @@ Available commands:
 
     When a record is found at this address, execution ends. The default address is 0x00001000.
 
-
   - **--host-out**
 
     Any entries to this address will print the messages as terminal output. The default address is 0x00000000, which means no messages.
@@ -36,6 +35,14 @@ Available commands:
   - **--quiet**
 
     Disable all messages.
+
+  - **--log-out**
+
+    Output file log, not specified by default.
+
+  - **--log-level**
+
+    Log level available: `DEBUG, INFO, WARNING, ERROR, CRITICAL, QUIET`. Default log level `DEBUG`.
 
 
 > Documentation for installing `Verilator` can be found here: [Installation](https://veripool.org/guide/latest/install.html)

--- a/hardware/core/tests/verilator/argparse.cpp
+++ b/hardware/core/tests/verilator/argparse.cpp
@@ -12,6 +12,8 @@
 #include <getopt.h>
 #include <string.h>
 
+#include "log.h"
+
 const char *help_str =
     "Use: app_name.run [options]\n"
     "Options:\n"
@@ -82,13 +84,6 @@ Args parser(int argc, char *argv[])
   Args args;
   int opt;
 
-  // Check first if --quiet was used. If so, disable output printing
-  for (int i = 0; i < argc; i++)
-    if (strcmp(argv[i], "--quiet") == 0)
-    {
-      args.sim_verbosity = QUIET;
-    }
-
   while ((opt = getopt_long(argc, argv, "", long_opts, NULL)) != -1)
   {
     switch (opt)
@@ -99,45 +94,40 @@ Args parser(int argc, char *argv[])
 
     case opts::cmd_out_wave:
       args.out_wave_path = optarg;
-      if (args.sim_verbosity != QUIET)
-        std::cout << "Wave out: " << optarg << std::endl;
+      Log::info("Wave out: %s", optarg);
       break;
 
     case opts::cmd_ram_init_h32:
       args.ram_init_h32 = optarg;
-      if (args.sim_verbosity != QUIET)
-        std::cout << "Input init ram file: " << optarg << std::endl;
+      Log::info("Input init ram file: %s", optarg);
       break;
 
     case opts::cmd_ram_dump_h32:
       args.ram_dump_h32 = optarg;
-      if (args.sim_verbosity != QUIET)
-        std::cout << "Output dump ram file: " << optarg << std::endl;
+      Log::info("Output dump ram file: %s", optarg);
       break;
 
     case opts::cmd_cycles:
       args.max_cycles = get_int_arg(optarg);
-      if (args.sim_verbosity != QUIET)
-        std::cout << "Max cycles: " << args.max_cycles << std::endl;
+      Log::info("Max cycles: %u", args.max_cycles);
       break;
 
     case opts::cmd_wr_addr:
       args.wr_addr = get_int_arg(optarg);
-      if (args.sim_verbosity != QUIET)
-        std::cout << "Write address: 0x" << std::hex << args.wr_addr << std::endl;
+      Log::info("Write address: 0x%x", args.wr_addr);
       break;
 
     case opts::cmd_host_out:
       args.host_out = get_int_arg(optarg);
-      if (args.sim_verbosity != QUIET)
-        std::cout << "Host out: 0x" << std::hex << args.host_out << std::endl;
+      Log::info("Host out: 0x%x", args.host_out);
       break;
 
     case opts::cmd_quiet:
+      Log::set_level(Log::QUIET);
       break;
 
     default:
-      std::cout << "Please call for help: --help\n\n";
+      Log::info("Please call for help: --help\n");
       std::exit(EXIT_SUCCESS);
     }
   }

--- a/hardware/core/tests/verilator/argparse.cpp
+++ b/hardware/core/tests/verilator/argparse.cpp
@@ -37,7 +37,7 @@ const char *help_str =
     "Note:                  Must not be 0x0\n\n"
 
     "--quiet                Use --quiet to disable messages (default: messages enable)\n"
-    "                       Example: --quiet (equivalent: --log-level=DEBUG)\n"
+    "                       Example: --quiet (equivalent: --log-level=QUIET)\n"
 
     "--log-out              Output file log (default: none)\n"
     "                       Example: --log-out=my_log.txt\n"

--- a/hardware/core/tests/verilator/argparse.cpp
+++ b/hardware/core/tests/verilator/argparse.cpp
@@ -26,18 +26,25 @@ const char *help_str =
     "\n\n"
 
     "The end of the program is:\n"
-    "--cycles=<num>         Exit after processor cycles complete (defaul: 500000)\n"
+    "--cycles=<num>         Exit after processor cycles complete (default: 500000)\n"
     "                       Example: --cycles=10000\n\n"
     //    "--ecall            Exit if there is an instruction ecall\n"
-    "--wr-addr=<addr>       Exit if there is an entry at the specified address (defaul: 0x00001000)\n"
+    "--wr-addr=<addr>       Exit if there is an entry at the specified address (default: 0x00001000)\n"
     "                       Example: --wr-addr=0x00001000)\n\n"
 
-    "--host-out=<addr>      Message output detection address (defaul: 0x00000000 - off)\n"
+    "--host-out=<addr>      Message output detection address (default: 0x00000000 - off)\n"
     "                       Example: --host-out=0x00000000\n"
     "Note:                  Must not be 0x0\n\n"
 
-    "--quiet                Use --quiet to disable messages (defaul: messages enable)\n"
-    "                       Example: --quiet\n"
+    "--quiet                Use --quiet to disable messages (default: messages enable)\n"
+    "                       Example: --quiet (equivalent: --log-level=DEBUG)\n"
+
+    "--log-out              Output file log (default: none)\n"
+    "                       Example: --log-out=my_log.txt\n"
+
+    "--log-level            Log level (default: DEBUG)\n"
+    "                       Example: --log-level=DEBUG\n"
+    "Note:                  Available: DEBUG, INFO, WARNING, ERROR, CRITICAL, QUIET\n\n"
 
     "\n\n"
     "Example:\n"
@@ -57,7 +64,9 @@ enum opts
   cmd_wr_addr,
   cmd_dump_h32,
   cmd_host_out,
-  cmd_quiet
+  cmd_quiet,
+  cmd_log_out,
+  cmd_log_level,
 };
 
 static constexpr option long_opts[] =
@@ -71,6 +80,8 @@ static constexpr option long_opts[] =
         {"wr-addr", required_argument, NULL, opts::cmd_wr_addr},
         {"host-out", required_argument, NULL, opts::cmd_host_out},
         {"quiet", no_argument, NULL, opts::cmd_quiet},
+        {"log-out", required_argument, NULL, opts::cmd_log_out},
+        {"log-level", required_argument, NULL, opts::cmd_log_level},
         {NULL, no_argument, NULL, 0}};
 
 static size_t get_int_arg(const char *arg)
@@ -124,6 +135,14 @@ Args parser(int argc, char *argv[])
 
     case opts::cmd_quiet:
       Log::set_level(Log::QUIET);
+      break;
+
+    case opts::cmd_log_out:
+      Log::set_out(optarg);
+      break;
+
+    case opts::cmd_log_level:
+      Log::set_level(optarg);
       break;
 
     default:

--- a/hardware/core/tests/verilator/argparse.h
+++ b/hardware/core/tests/verilator/argparse.h
@@ -25,7 +25,6 @@ struct Args
   uint32_t max_cycles{500000};
   uint32_t wr_addr{0x00001000};
   uint32_t host_out{0x00000000};
-  verbosity sim_verbosity{VERBOSE};
 };
 
 Args parser(int argc, char *argv[]);

--- a/hardware/core/tests/verilator/argparse.h
+++ b/hardware/core/tests/verilator/argparse.h
@@ -11,12 +11,6 @@
 #include <cstdint>
 #include <cstddef>
 
-enum verbosity
-{
-  QUIET,
-  VERBOSE
-};
-
 struct Args
 {
   char *out_wave_path{nullptr};

--- a/hardware/core/tests/verilator/log.h
+++ b/hardware/core/tests/verilator/log.h
@@ -31,6 +31,7 @@ class Log
       case WARNING: return "WARNING";
       case ERROR: return "ERROR";
       case CRITICAL: return "CRITICAL";
+      case QUIET: return "QUIET";
       default: return "UNKNOWN";
       }
     }

--- a/hardware/core/tests/verilator/log.h
+++ b/hardware/core/tests/verilator/log.h
@@ -20,10 +20,11 @@ class Log
       WARNING,
       ERROR,
       CRITICAL,
-      QUIET
+      QUIET,
+      END
     };
 
-    const char *level_name(Level level) {
+    static const char *level_name(Level level) {
       switch(level) {
       case DEBUG: return "DEBUG";
       case INFO: return "INFO";
@@ -44,7 +45,20 @@ class Log
       get_instance().level = level;
     }
 
-    static void set_fileout(const std::string& filename)
+    static void set_level(const char * level)
+    {
+      for (int i = 0; i < Level::END; i++)
+      {
+        const char *name = level_name((Level)i);
+
+        if (strcmp(level, name) == 0)
+        {
+          get_instance().set_level((Level)i);
+        }
+      }
+    }
+
+    static void set_out(const std::string& filename)
     {
       Log &log = get_instance();
       log.fileout.open(filename, std::ios::out | std::ios::trunc);

--- a/hardware/core/tests/verilator/log.h
+++ b/hardware/core/tests/verilator/log.h
@@ -1,0 +1,128 @@
+#ifndef LOG_H
+#define LOG_H
+
+#include <cstddef>
+#include <iostream>
+#include <sstream>
+#include <fstream>
+#include <cstring>
+
+class Log
+{
+  public:
+    ~Log() = default;
+    static constexpr size_t BUFFER_SIZE = 1024;
+
+    enum Level
+    {
+      DEBUG,
+      INFO,
+      WARNING,
+      ERROR,
+      CRITICAL,
+      QUIET
+    };
+
+    const char *level_name(Level level) {
+      switch(level) {
+      case DEBUG: return "DEBUG";
+      case INFO: return "INFO";
+      case WARNING: return "WARNING";
+      case ERROR: return "ERROR";
+      case CRITICAL: return "CRITICAL";
+      default: return "UNKNOWN";
+      }
+    }
+
+    static Log& get_instance() {
+        static Log instance;
+        return instance;
+    }
+
+    static void set_level(const Level level)
+    {
+      get_instance().level = level;
+    }
+
+    static void set_fileout(const std::string& filename)
+    {
+      Log &log = get_instance();
+      log.fileout.open(filename, std::ios::out | std::ios::trunc);
+
+      if (log.fileout.is_open())
+      {
+        log.log_stream = &log.fileout;
+      }
+    }
+
+    template<typename... Targs>
+    static void debug(const char* format, Targs... Fargs)
+    {
+      get_instance().message(DEBUG, format, Fargs...);
+    }
+
+    template<typename... Targs>
+    static void info(const char* format, Targs... Fargs)
+    {
+      get_instance().message(INFO, format, Fargs...);
+    }
+
+    template<typename... Targs>
+    static void warning(const char* format, Targs... Fargs)
+    {
+      get_instance().message(WARNING, format, Fargs...);
+    }
+
+    template<typename... Targs>
+    static void error(const char* format, Targs... Fargs)
+    {
+      get_instance().message(ERROR, format, Fargs...);
+    }
+
+    template<typename... Targs>
+    static void critical(const char* format, Targs... Fargs)
+    {
+      get_instance().message(CRITICAL, format, Fargs...);
+    }
+
+  private:
+    char buffer[BUFFER_SIZE];
+    Level level{DEBUG};
+    std::ofstream fileout;
+    std::ostream* log_stream{&std::cout};
+
+    Log() = default;
+
+    template<typename... Targs>
+    void message(Level level, const char* format, Targs... Fargs);
+
+    template<typename... Targs>
+    void message(std::stringstream &ss, const char* format, Targs... Fargs);
+
+    template<typename... Targs>
+    void message(std::stringstream &ss, const char* str)
+    {
+      ss << str;
+    }
+};
+
+template<typename... Targs>
+void Log::message(Level level, const char* format, Targs... Fargs)
+{
+  if (level >= this->level)
+  {
+    std::stringstream ss;
+    message(ss, "[%s] ", level_name(level));
+    message(ss, format, Fargs...);
+    *log_stream << ss.str() << std::endl;
+  }
+}
+
+template<typename... Targs>
+void Log::message(std::stringstream &ss, const char* format, Targs... Fargs)
+{
+  snprintf(buffer, sizeof(buffer), format, Fargs...);
+  ss << buffer;
+}
+
+#endif // LOG_H

--- a/hardware/core/tests/verilator/main.cpp
+++ b/hardware/core/tests/verilator/main.cpp
@@ -11,6 +11,7 @@
 #include <fstream>
 #include <signal.h>
 #include <string.h>
+#include "log.h"
 
 #include <verilated_vcd_c.h>
 #include <verilated_fst_c.h>
@@ -81,8 +82,7 @@ void exit_app(int sig)
 {
   (void)sig;
   close_trace();
-  if (args.sim_verbosity != QUIET)
-    std::cout << "Exit." << std::endl;
+  Log::info("Exit.");
   std::exit(EXIT_SUCCESS);
 }
 
@@ -94,7 +94,7 @@ void ram_init_h32(const char *path)
 
   if (!file.is_open())
   {
-    std::cout << "Error file opening: " << path << std::endl;
+    Log::error("Error file opening: %s", path);
     std::exit(EXIT_FAILURE);
   }
 
@@ -125,7 +125,7 @@ void ram_init_h32(const char *path)
 
         if (load_address > ram_size)
         {
-          std::cout << "Out of range load address ram: 0x" << std::hex << load_address << std::endl;
+          Log::error("Out of range load address ram: 0x%x", load_address);
           std::exit(EXIT_FAILURE);
         }
 
@@ -136,8 +136,7 @@ void ram_init_h32(const char *path)
     }
   }
 
-  if (args.sim_verbosity != QUIET)
-    std::cout << "Ok init ram h32" << std::endl;
+  Log::info("Ok init ram h32");
   file.close();
 }
 
@@ -148,7 +147,7 @@ void ram_dump_h32(const char *path, uint32_t offset, uint32_t size)
 
   if (!file.is_open())
   {
-    std::cout << "Error file opening: " << path << std::endl;
+    Log::error("Error file opening: %s", path);
     std::exit(EXIT_FAILURE);
   }
 
@@ -165,8 +164,7 @@ void ram_dump_h32(const char *path, uint32_t offset, uint32_t size)
     file << buff << '\n';
   }
 
-  if (args.sim_verbosity != QUIET)
-    std::cout << "Ok dump ram h32" << std::endl;
+  Log::info("Ok dump ram h32");
   file.close();
 }
 
@@ -227,8 +225,7 @@ int main(int argc, char *argv[])
     {
       if (clk_cur_cycles >= args.max_cycles)
       {
-        if (args.sim_verbosity != QUIET)
-          std::cout << "Exit: end cycles" << std::endl;
+        Log::info("Exit: end cycles");
         close_trace();
         std::exit(EXIT_SUCCESS);
       }
@@ -237,16 +234,14 @@ int main(int argc, char *argv[])
     // --wr-addr
     if (is_finished(args.wr_addr))
     {
-      if (args.sim_verbosity != QUIET)
-        std::cout << "Exit: wr-addr" << std::endl;
+      Log::info("Exit: wr-addr");
 
       // The beginning and end of signature are stored at
       uint32_t start_addr = get_signature(2047);
       uint32_t stop_addr = get_signature(2046);
       uint32_t size = stop_addr - start_addr;
 
-      if (args.sim_verbosity != QUIET)
-        std::cout << "Signature size: " << std::dec << size << std::endl;
+      Log::info("Signature size: %u", size);
 
       if (args.ram_dump_h32 and (size >= 4))
       {

--- a/hardware/core/tests/verilator/main.cpp
+++ b/hardware/core/tests/verilator/main.cpp
@@ -202,6 +202,8 @@ int main(int argc, char *argv[])
   signal(SIGINT, exit_app);
   signal(SIGKILL, exit_app);
 
+  // Default log level
+  Log::set_level(Log::DEBUG);
   args = parser(argc, argv);
 
   if (args.out_wave_path)


### PR DESCRIPTION
Added log output options.

`--quiet` equivalent `--log-level=QUIET`
`--log-out` output log file
`--log-level` log level available `DEBUG, INFO, WARNING, ERROR, CRITICAL, QUIET`. 

Default log level `DEBUG`