### PR TITLE
Added fast IRQ (extension CSR regs mie and mip)

### DIFF
--- a/hardware/core/rvsteel_core.v
+++ b/hardware/core/rvsteel_core.v
@@ -1514,12 +1514,12 @@ module rvsteel_core #(
         csr_mcause_code           <= 5'b1011;
         csr_mcause_interrupt_flag <= 1'b1;
       end
-      else if(csr_mstatus_mie & csr_mie_mtie & csr_mip_mtip) begin
-        csr_mcause_code           <= 5'b0111;
-        csr_mcause_interrupt_flag <= 1'b1;
-      end
       else if(csr_mstatus_mie & csr_mie_msie & csr_mip_msip) begin
         csr_mcause_code           <= 5'b0011;
+        csr_mcause_interrupt_flag <= 1'b1;
+      end
+      else if(csr_mstatus_mie & csr_mie_mtie & csr_mip_mtip) begin
+        csr_mcause_code           <= 5'b0111;
         csr_mcause_interrupt_flag <= 1'b1;
       end
     end

--- a/hardware/core/tests/verilator/unit_tests.v
+++ b/hardware/core/tests/verilator/unit_tests.v
@@ -59,11 +59,13 @@ dut0
     .irq_external           (1'b0),
     .irq_timer              (1'b0),
     .irq_software           (1'b0),
+    .irq_fast               (16'b0),
 
     // verilator lint_off PINCONNECTEMPTY
     .irq_external_response  (),
     .irq_timer_response     (),
     .irq_software_response  (),
+    .irq_fast_response      (),
     // verilator lint_on PINCONNECTEMPTY
 
     // Real Time Clock (hardwire to zero if unused)

--- a/hardware/soc/rvsteel_soc.v
+++ b/hardware/soc/rvsteel_soc.v
@@ -39,7 +39,7 @@ module rvsteel_soc #(
   localparam D0_RAM         = 0;
   localparam D1_UART        = 1;
 
-  wire  [NUM_DEVICES*32-1:0] device_start_address;     
+  wire  [NUM_DEVICES*32-1:0] device_start_address;
   wire  [NUM_DEVICES*32-1:0] device_region_size;
 
   assign device_start_address [32*D0_RAM  +: 32]  = 32'h0000_0000;
@@ -98,9 +98,14 @@ module rvsteel_soc #(
     .irq_external                   (irq_external                       ),
     .irq_external_response          (irq_external_response              ),
     .irq_timer                      (0), // unused
-    .irq_timer_response             (),  // unused
     .irq_software                   (0), // unused
+    .irq_fast                       (0), // unused
+
+    // verilator lint_off PINCONNECTEMPTY
+    .irq_timer_response             (),  // unused
     .irq_software_response          (),  // unused
+    .irq_fast_response              (),  // unused
+    // verilator lint_on PINCONNECTEMPTY
 
     // Real Time Clock (hardwire to zero if unused)
 


### PR DESCRIPTION
Now rvsteel can handle fast IRQ from any peripheral devices. 16 additional IRQ inputs are available.
The priority now looks like this:

```
IRQ Fast[0], 
IRQ Fast[1], 
..., 
IRQ Fast[15], 
Machine external interrupt,
Machine timer interrupt,
Machine software interrupt
```

> `IRQ Fast[0]` has the highest priority.


By the way, I noticed that rvsteel doesn't seem to handle the priority correctly for `MEI, MSI, MTI`. 
Quote:

```
Multiple simultaneous interrupts destined for M-mode are handled in the following decreasing
priority order: MEI, MSI, MTI, SEI, SSI, STI.
```

And rvsteel does this: `MEI, MTI, MSI` (`meie, mtie, msie`). What do you think about this @rafaelcalcada ?

> I didn't fix it, I want you to look at it.
